### PR TITLE
Allow multiple regions for RTP

### DIFF
--- a/src/main/java/dev/warriorrr/simplertp/PlayerListener.java
+++ b/src/main/java/dev/warriorrr/simplertp/PlayerListener.java
@@ -1,5 +1,6 @@
 package dev.warriorrr.simplertp;
 
+import dev.warriorrr.simplertp.compat.TownyCompat;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -22,6 +23,7 @@ public class PlayerListener implements Listener {
             return;
 
         final Location location = plugin.generator().getAndRemove();
+        if (location == null) return;
         event.setSpawnLocation(location);
 
         final Player player = event.getPlayer();
@@ -34,7 +36,7 @@ public class PlayerListener implements Listener {
             return;
 
         // Return if the player is already being teleported to a respawn anchor or bed, or the respawn is already being handled by towny
-        if (event.isAnchorSpawn() || event.isBedSpawn() || (plugin.townyCompat() != null && plugin.townyCompat().handlesRespawn(event.getPlayer(), event.getPlayer().getLocation())))
+        if (event.isAnchorSpawn() || event.isBedSpawn() || (TownyCompat.getEnabled() && TownyCompat.handlesRespawn(event.getPlayer(), event.getPlayer().getLocation())))
             return;
 
         event.setRespawnLocation(plugin.generator().generateRespawnLocation(event.getPlayer().getLocation()));

--- a/src/main/java/dev/warriorrr/simplertp/PlayerListener.java
+++ b/src/main/java/dev/warriorrr/simplertp/PlayerListener.java
@@ -23,7 +23,6 @@ public class PlayerListener implements Listener {
             return;
 
         final Location location = plugin.generator().getAndRemove();
-        if (location == null) return;
         event.setSpawnLocation(location);
 
         final Player player = event.getPlayer();

--- a/src/main/java/dev/warriorrr/simplertp/PlayerListener.java
+++ b/src/main/java/dev/warriorrr/simplertp/PlayerListener.java
@@ -35,7 +35,7 @@ public class PlayerListener implements Listener {
             return;
 
         // Return if the player is already being teleported to a respawn anchor or bed, or the respawn is already being handled by towny
-        if (event.isAnchorSpawn() || event.isBedSpawn() || (TownyCompat.getEnabled() && TownyCompat.handlesRespawn(event.getPlayer(), event.getPlayer().getLocation())))
+        if (event.isAnchorSpawn() || event.isBedSpawn() || TownyCompat.handlesRespawn(event.getPlayer(), event.getPlayer().getLocation()))
             return;
 
         event.setRespawnLocation(plugin.generator().generateRespawnLocation(event.getPlayer().getLocation()));

--- a/src/main/java/dev/warriorrr/simplertp/PlayerListener.java
+++ b/src/main/java/dev/warriorrr/simplertp/PlayerListener.java
@@ -1,6 +1,7 @@
 package dev.warriorrr.simplertp;
 
 import dev.warriorrr.simplertp.compat.TownyCompat;
+import dev.warriorrr.simplertp.model.GeneratedLocation;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -22,11 +23,12 @@ public class PlayerListener implements Listener {
         if (event.getPlayer().hasPlayedBefore() || !plugin.config().rtpFirstJoin())
             return;
 
-        final Location location = plugin.generator().getAndRemove();
+        final GeneratedLocation generatedLoc = plugin.generator().getAndRemove();
+        final Location location = generatedLoc.location();
         event.setSpawnLocation(location);
 
         final Player player = event.getPlayer();
-        player.getScheduler().runDelayed(plugin, task -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + "."), () -> {}, 1L);
+        player.getScheduler().runDelayed(plugin, task -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + " in " + generatedLoc.region().name() + "."), () -> {}, 1L);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)

--- a/src/main/java/dev/warriorrr/simplertp/RTPConfig.java
+++ b/src/main/java/dev/warriorrr/simplertp/RTPConfig.java
@@ -6,15 +6,15 @@ import org.bukkit.Registry;
 import org.bukkit.Tag;
 import org.bukkit.block.Biome;
 
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 public class RTPConfig {
     private final SimpleRTP plugin;
 
     private final Set<Biome> blacklistedBiomes = new HashSet<>();
     private final Set<Material> blacklistedBlocks = new HashSet<>();
+    private final Map<Region, Integer> regions = new HashMap<>();
+    private static int blocksNeededPerUse = 1000;
 
     public RTPConfig(SimpleRTP plugin) {
         this.plugin = plugin;
@@ -25,6 +25,8 @@ public class RTPConfig {
         blacklistedBiomes.clear();
         plugin.reloadConfig();
 
+        blocksNeededPerUse = plugin.getConfig().getInt("surfaceAreaPerUse");
+
         for (final String biomeName : plugin.getConfig().getStringList("blacklisted-biomes")) {
             final NamespacedKey key = NamespacedKey.fromString(biomeName.toLowerCase(Locale.ROOT));
 
@@ -34,10 +36,12 @@ public class RTPConfig {
             }
 
             final Biome biome = Registry.BIOME.get(key);
-            if (biome != null)
+            if (biome != null) {
                 blacklistedBiomes.add(biome);
-            else
+
+            } else {
                 plugin.getLogger().warning("Could not find a biome with key " + key);
+            }
         }
 
         for (final String block : plugin.getConfig().getStringList("blacklisted-blocks")) {
@@ -55,28 +59,46 @@ public class RTPConfig {
                 // No material with this name found, check if it's a valid tag
                 final Tag<Material> tag = plugin.getServer().getTag(Tag.REGISTRY_BLOCKS, key, Material.class);
 
-                if (tag != null)
+                if (tag != null) {
                     blacklistedBlocks.addAll(tag.getValues());
-                else
+                } else {
                     plugin.getLogger().warning("Could not find a material/tag for block '" +block + "'.");
+                }
+            }
+        }
+
+        for (final String region : plugin.getConfig().getStringList("allowed-regions")) { // E.g. 100,50,45,20;minX,maxX,minZ,maxZ
+            for (String coords : region.split(";")) {
+                String[] coord = coords.split(",");
+                int minX, maxX, minZ, maxZ;
+                try {
+                    minX = Integer.parseInt(coord[0]);
+                    maxX = Integer.parseInt(coord[1]);
+                    minZ = Integer.parseInt(coord[2]);
+                    maxZ = Integer.parseInt(coord[3]);
+                } catch (NumberFormatException | IndexOutOfBoundsException e) {
+                    plugin.getLogger().warning("Could not parse %s into integers".formatted(coords) + "\n" + e.getMessage());
+                    continue;
+                }
+                regions.put(new Region(minX, maxX, minZ, maxZ), 0);
             }
         }
     }
 
-    public int getMinX() {
-        return plugin.getConfig().getInt("minX");
+    public record Region(int minX, int maxX, int minZ, int maxZ) {
+        public int maxUses() {
+            return ((maxX - minX) * (maxZ - minZ)) / blocksNeededPerUse; // For every 1000 blocks of surface area, region can be used once.
+        }
     }
 
-    public int getMaxX() {
-        return plugin.getConfig().getInt("maxX");
-    }
-
-    public int getMinZ() {
-        return plugin.getConfig().getInt("minZ");
-    }
-
-    public int getMaxZ() {
-        return plugin.getConfig().getInt("maxZ");
+    public Region getNextRegion() {
+        Iterator<Region> it = regions.keySet().iterator();
+        Region next = it.next();
+        while (next.maxUses() <= regions.get(next)) {
+            regions.remove(next);
+            next = it.next();
+        }
+        return next;
     }
 
     public int getMaxY() {

--- a/src/main/java/dev/warriorrr/simplertp/RTPConfig.java
+++ b/src/main/java/dev/warriorrr/simplertp/RTPConfig.java
@@ -92,7 +92,7 @@ public class RTPConfig {
                     (int) area.get("minX"),
                     (int) area.get("maxX"),
                     (int) area.get("minZ"),
-                    (int) area.get("minZ")
+                    (int) area.get("maxZ")
                 ));
             }
             if (areas.isEmpty()) return;
@@ -114,7 +114,7 @@ public class RTPConfig {
                 c += a.size();
                 if (c > random) return a;
             }
-            return areas.getFirst();
+            return areas.get(0);
         }
         public int size() {
             AtomicInteger size = new AtomicInteger();
@@ -142,7 +142,7 @@ public class RTPConfig {
             c += r.size();
             if (c > random) return r;
         }
-        return regionList.getFirst();
+        return regionList.get(0);
     }
 
     public List<Region> getRegions() {

--- a/src/main/java/dev/warriorrr/simplertp/SimpleRTP.java
+++ b/src/main/java/dev/warriorrr/simplertp/SimpleRTP.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 public final class SimpleRTP extends JavaPlugin {
     private final RTPConfig config = new RTPConfig(this);
     private LocationGenerator generator;
+    private TeleportHandler teleportHandler;
 
     @Override
     public void onEnable() {
@@ -29,8 +30,10 @@ public final class SimpleRTP extends JavaPlugin {
         this.generator = new LocationGenerator(this, world);
         generator.start();
 
+        teleportHandler = new TeleportHandler(this);
+        Bukkit.getPluginManager().registerEvents(teleportHandler, this);
         Bukkit.getPluginManager().registerEvents(new PlayerListener(this), this);
-        Objects.requireNonNull(getCommand("rtp")).setExecutor(new RTPCommand(this));
+        Objects.requireNonNull(getCommand("rtp")).setExecutor(new RTPCommand(this, teleportHandler));
 
         if (Bukkit.getPluginManager().isPluginEnabled("Towny")) {
             TownyCompat.enable();
@@ -53,5 +56,9 @@ public final class SimpleRTP extends JavaPlugin {
 
     public void reload() {
         this.config.loadConfig();
+    }
+
+    public TeleportHandler teleportHandler() {
+        return teleportHandler;
     }
 }

--- a/src/main/java/dev/warriorrr/simplertp/SimpleRTP.java
+++ b/src/main/java/dev/warriorrr/simplertp/SimpleRTP.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 public final class SimpleRTP extends JavaPlugin {
     private final RTPConfig config = new RTPConfig(this);
     private LocationGenerator generator;
-    private TownyCompat townyCompat;
 
     @Override
     public void onEnable() {
@@ -33,8 +32,9 @@ public final class SimpleRTP extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new PlayerListener(this), this);
         Objects.requireNonNull(getCommand("rtp")).setExecutor(new RTPCommand(this));
 
-        if (Bukkit.getPluginManager().isPluginEnabled("Towny"))
-            townyCompat = new TownyCompat();
+        if (Bukkit.getPluginManager().isPluginEnabled("Towny")) {
+            TownyCompat.enable();
+        }
     }
 
     @Override
@@ -53,9 +53,5 @@ public final class SimpleRTP extends JavaPlugin {
 
     public void reload() {
         this.config.loadConfig();
-    }
-
-    public TownyCompat townyCompat() {
-        return townyCompat;
     }
 }

--- a/src/main/java/dev/warriorrr/simplertp/TeleportHandler.java
+++ b/src/main/java/dev/warriorrr/simplertp/TeleportHandler.java
@@ -1,0 +1,59 @@
+package dev.warriorrr.simplertp;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class TeleportHandler implements Listener {
+    private final SimpleRTP plugin;
+    private final Map<UUID, ScheduledTask> teleports = new HashMap<>();
+
+    public TeleportHandler(SimpleRTP plugin) {
+        this.plugin = plugin;
+    }
+
+    public void addTeleport(Player player, Location location) {
+        ScheduledTask task = plugin.getServer().getRegionScheduler().runDelayed(plugin, location,
+                t -> player.teleportAsync(location).thenRun(() -> {
+            player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + ".");
+            teleports.remove(player.getUniqueId());
+        }), 3 * 20);
+        teleports.put(player.getUniqueId(), task);
+    }
+
+    public boolean hasTeleport(Player player) {
+        return teleports.containsKey(player.getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        ScheduledTask task = teleports.remove(player.getUniqueId());
+        if (task != null && !task.isCancelled()) {
+            task.cancel();
+            player.sendMessage(Component.text("Teleportation cancelled due to movement.", NamedTextColor.DARK_RED));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        if (!event.hasChangedBlock()) return;
+        ScheduledTask task = teleports.remove(player.getUniqueId());
+        if (task != null && !task.isCancelled()) {
+            task.cancel();
+            player.sendMessage(Component.text("Teleportation cancelled due to movement.", NamedTextColor.DARK_RED));
+        }
+    }
+}

--- a/src/main/java/dev/warriorrr/simplertp/collection/ImmutableQueue.java
+++ b/src/main/java/dev/warriorrr/simplertp/collection/ImmutableQueue.java
@@ -1,0 +1,50 @@
+package dev.warriorrr.simplertp.collection;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+
+public class ImmutableQueue<E> extends AbstractQueue<E> {
+    private static final ImmutableQueue<?> INSTANCE = new ImmutableQueue<>();
+
+    @SuppressWarnings("unchecked")
+    public static <T> ImmutableQueue<T> instance() {
+        return (ImmutableQueue<T>) INSTANCE;
+    }
+
+    @Override
+    public @NotNull Iterator<E> iterator() {
+        return new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public E next() {
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public boolean offer(E e) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public E poll() {
+        return null;
+    }
+
+    @Override
+    public E peek() {
+        return null;
+    }
+}

--- a/src/main/java/dev/warriorrr/simplertp/collection/WeightedCollection.java
+++ b/src/main/java/dev/warriorrr/simplertp/collection/WeightedCollection.java
@@ -1,0 +1,30 @@
+package dev.warriorrr.simplertp.collection;
+
+import java.util.NavigableMap;
+import java.util.Random;
+import java.util.TreeMap;
+
+public class WeightedCollection<E> {
+    private final NavigableMap<Integer, E> map = new TreeMap<>();
+    private final Random random;
+    private int total = 0;
+
+    public WeightedCollection() {
+        this(new Random());
+    }
+
+    public WeightedCollection(Random random) {
+        this.random = random;
+    }
+
+    public void add(int weight, E object) {
+        if (weight <= 0) return;
+        total += weight;
+        map.put(total, object);
+    }
+
+    public E next() {
+        int value = random.nextInt(total) + 1; // Can also use floating-point weights
+        return map.ceilingEntry(value).getValue();
+    }
+}

--- a/src/main/java/dev/warriorrr/simplertp/commands/RTPCommand.java
+++ b/src/main/java/dev/warriorrr/simplertp/commands/RTPCommand.java
@@ -1,5 +1,6 @@
 package dev.warriorrr.simplertp.commands;
 
+import dev.warriorrr.simplertp.RTPConfig;
 import dev.warriorrr.simplertp.SimpleRTP;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -8,10 +9,16 @@ import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public class RTPCommand implements CommandExecutor {
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class RTPCommand implements TabExecutor {
     private final SimpleRTP plugin;
 
     public RTPCommand(SimpleRTP plugin) {
@@ -20,13 +27,13 @@ public class RTPCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (args.length == 0) {
+        if (!sender.hasPermission("simplertp.command.rtp")) {
+            sender.sendMessage(Component.text("You do not have permissions to use this command.", NamedTextColor.RED));
+            return true;
+        }
+        if (args.length == 0 || args[0].equalsIgnoreCase("tp")) {
             if (!(sender instanceof Player player)) {
-                sender.sendMessage(Component.text("This command cannot be used by console! See also: /rtp reload, /rtp [name]", NamedTextColor.RED));
-                return true;
-            }
-            if (!player.hasPermission("simplertp.command.rtp")) {
-                player.sendMessage(Component.text("You do not have permissions to use this command.", NamedTextColor.RED));
+                sender.sendMessage(Component.text("This command cannot be used by console! See also: /rtp reload, /rtp player {name}", NamedTextColor.RED));
                 return true;
             }
             final Location location = plugin.generator().getAndRemove();
@@ -37,36 +44,82 @@ public class RTPCommand implements CommandExecutor {
             player.teleportAsync(location).thenRun(() -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + "."));
             return true;
         }
-
-        if ("reload".equalsIgnoreCase(args[0])) {
-            if (!sender.hasPermission("simplertp.command.rtp.reload"))
-                sender.sendMessage(Component.text("You do not have permission to use this command.", NamedTextColor.RED));
-            else {
-                plugin.reload();
-                sender.sendMessage(Component.text("Reloaded config.", NamedTextColor.GREEN));
-            }
-            return true;
-        }
-
-        if (!sender.hasPermission("simplertp.command.rtp.others")) {
-            sender.sendMessage(Component.text("You do not have permission to use this command.", NamedTextColor.RED));
-            return true;
-        }
-        Player player = Bukkit.getPlayer(args[0]);
-        if (player == null) {
-            sender.sendMessage(Component.text("Invalid subcommand: '" + args[0] + "'.", NamedTextColor.RED));
-            return true;
-        }
         final Location location = plugin.generator().getAndRemove();
         if (location == null) {
             sender.sendMessage(Component.text("Could not find a suitable location.").color(NamedTextColor.RED));
             return true;
         }
-        player.getScheduler().run(plugin, task -> {
-            player.teleportAsync(location).thenRun(() -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + "."));
-            sender.sendMessage(Component.text("Randomly teleported " + player.getName() + " to " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + ".", NamedTextColor.GREEN));
-        }, () -> {});
 
+        switch (args[0].toLowerCase()) {
+            case "reload" -> {
+                if (!sender.hasPermission("simplertp.command.rtp.reload")) {
+                    sender.sendMessage(Component.text("You do not have permission to use this command.", NamedTextColor.RED));
+                    return true;
+                }
+                plugin.reload();
+                sender.sendMessage(Component.text("Reloaded config.", NamedTextColor.GREEN));
+                return true;
+            }
+            case "player" -> {
+                if (!sender.hasPermission("simplertp.command.rtp.others")) {
+                    sender.sendMessage(Component.text("You do not have permission to use this command.", NamedTextColor.RED));
+                    return true;
+                }
+                if (args.length < 2) {
+                    sender.sendMessage(Component.text("Usage: /rtp player {name}", NamedTextColor.RED));
+                    return true;
+                }
+                Player player = Bukkit.getPlayer(args[0]);
+                if (player == null) {
+                    sender.sendMessage(Component.text("Player not found.", NamedTextColor.RED));
+                    return true;
+                }
+                player.getScheduler().run(plugin, task -> {
+                    player.teleportAsync(location).thenRun(() -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + "."));
+                    sender.sendMessage(Component.text("Randomly teleported " + player.getName() + " to " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + ".", NamedTextColor.GREEN));
+                }, () -> {});
+            }
+            case "region" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(Component.text("This command cannot be used by console! See also: /rtp reload, /rtp player {name}", NamedTextColor.RED));
+                    return true;
+                }
+                if (!sender.hasPermission("simplertp.command.rtp.region")) {
+                    sender.sendMessage(Component.text("You do not have permission to use this command.", NamedTextColor.RED));
+                    return true;
+                }
+                if (args.length < 2) {
+                    sender.sendMessage(Component.text("Usage: /rtp region {name}", NamedTextColor.RED));
+                    return true;
+                }
+                String name = args[1];
+                RTPConfig.Region region = plugin.config().getRegions().stream().filter(r -> r.name().equalsIgnoreCase(name)).toList().getFirst();
+                if (region == null) {
+                    sender.sendMessage(Component.text("Could not find region with that name.", NamedTextColor.RED));
+                    return true;
+                }
+                Location regionLoc = plugin.generator().getSpawnForRegion(region);
+                if (regionLoc == null) {
+                    sender.sendMessage(Component.text("Could not find a suitable spawn", NamedTextColor.RED));
+                    plugin.getLogger().warning("Could not find suitable spawn for region " + region.name());
+                    return true;
+                }
+                player.teleportAsync(regionLoc).thenRun(() -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + "."));
+            }
+        }
         return true;
+    }
+
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
+        List<String> choices = new ArrayList<>();
+        if (commandSender.hasPermission("simplertp.command.rtp.reload")) choices.add("reload");
+        if (commandSender.hasPermission("simplertp.command.rtp.others")) choices.add("others");
+        if (commandSender.hasPermission("simplertp.command.rtp.region")) choices.add("region");
+        if (strings.length == 1) {
+            return choices.stream().filter(str -> str.startsWith(strings[0])).toList();
+        }
+        return List.of();
     }
 }

--- a/src/main/java/dev/warriorrr/simplertp/commands/RTPCommand.java
+++ b/src/main/java/dev/warriorrr/simplertp/commands/RTPCommand.java
@@ -21,44 +21,52 @@ public class RTPCommand implements CommandExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (args.length == 0) {
-            if (!(sender instanceof Player player))
+            if (!(sender instanceof Player player)) {
                 sender.sendMessage(Component.text("This command cannot be used by console! See also: /rtp reload, /rtp [name]", NamedTextColor.RED));
-            else {
-                if (!player.hasPermission("simplertp.command.rtp"))
-                    player.sendMessage(Component.text("You do not have enough permissions to use this command.", NamedTextColor.RED));
-                else {
-                    final Location location = plugin.generator().getAndRemove();
-                    player.teleportAsync(location).thenRun(() -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + "."));
-                }
+                return true;
             }
-        } else {
-            if ("reload".equalsIgnoreCase(args[0])) {
-                if (!sender.hasPermission("simplertp.command.rtp.reload"))
-                    sender.sendMessage(Component.text("You do not have enough permission to use this command.", NamedTextColor.RED));
-                else {
-                    plugin.reload();
-                    sender.sendMessage(Component.text("Reloaded config.", NamedTextColor.GREEN));
-                }
-            } else {
-                if (!sender.hasPermission("simplertp.command.rtp.others"))
-                    sender.sendMessage(Component.text("You do not have enough permission to use this command.", NamedTextColor.RED));
-                else if (Bukkit.getPlayerExact(args[0]) != null) {
-                    final Player player = Bukkit.getPlayerExact(args[0]);
-                    if (player == null) {
-                        sender.sendMessage(Component.text("Could not find a player named " + args[0] + ".", NamedTextColor.RED));
-                        return true;
-                    }
-
-                    final Location location = plugin.generator().getAndRemove();
-                    player.getScheduler().run(plugin, task -> {
-                        player.teleportAsync(location).thenRun(() -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + "."));
-                        sender.sendMessage(Component.text("Randomly teleported " + player.getName() + " to " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + ".", NamedTextColor.GREEN));
-                    }, () -> {});
-                } else {
-                    sender.sendMessage(Component.text("Invalid subcommand: '" + args[0] + "'.", NamedTextColor.RED));
-                }
+            if (!player.hasPermission("simplertp.command.rtp")) {
+                player.sendMessage(Component.text("You do not have permissions to use this command.", NamedTextColor.RED));
+                return true;
             }
+            final Location location = plugin.generator().getAndRemove();
+            if (location == null) {
+                sender.sendMessage(Component.text("Could not find a suitable location.").color(NamedTextColor.RED));
+                return true;
+            }
+            player.teleportAsync(location).thenRun(() -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + "."));
+            return true;
         }
+
+        if ("reload".equalsIgnoreCase(args[0])) {
+            if (!sender.hasPermission("simplertp.command.rtp.reload"))
+                sender.sendMessage(Component.text("You do not have permission to use this command.", NamedTextColor.RED));
+            else {
+                plugin.reload();
+                sender.sendMessage(Component.text("Reloaded config.", NamedTextColor.GREEN));
+            }
+            return true;
+        }
+
+        if (!sender.hasPermission("simplertp.command.rtp.others")) {
+            sender.sendMessage(Component.text("You do not have permission to use this command.", NamedTextColor.RED));
+            return true;
+        }
+        Player player = Bukkit.getPlayer(args[0]);
+        if (player == null) {
+            sender.sendMessage(Component.text("Invalid subcommand: '" + args[0] + "'.", NamedTextColor.RED));
+            return true;
+        }
+        final Location location = plugin.generator().getAndRemove();
+        if (location == null) {
+            sender.sendMessage(Component.text("Could not find a suitable location.").color(NamedTextColor.RED));
+            return true;
+        }
+        player.getScheduler().run(plugin, task -> {
+            player.teleportAsync(location).thenRun(() -> player.sendRichMessage("<gradient:blue:aqua>You have been randomly teleported to: " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + "."));
+            sender.sendMessage(Component.text("Randomly teleported " + player.getName() + " to " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() + ".", NamedTextColor.GREEN));
+        }, () -> {});
+
         return true;
     }
 }

--- a/src/main/java/dev/warriorrr/simplertp/compat/TownyCompat.java
+++ b/src/main/java/dev/warriorrr/simplertp/compat/TownyCompat.java
@@ -2,27 +2,24 @@ package dev.warriorrr.simplertp.compat;
 
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownySettings;
-import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.WorldCoord;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 public class TownyCompat {
-    private static boolean enabled;
+    private static boolean enabled = false;
 
     public static void enable() {
         enabled = true;
     }
-    public static boolean getEnabled() {
-        return enabled;
-    }
 
     public static boolean isWilderness(World world, int x, int z) {
-        return TownyAPI.getInstance().isWilderness(WorldCoord.parseWorldCoord(world.getName(), x, z));
+        return !enabled || TownyAPI.getInstance().isWilderness(WorldCoord.parseWorldCoord(world.getName(), x, z));
     }
 
     public static boolean handlesRespawn(Player player, Location deathLocation) {
+        if (!enabled) return false;
         if (!TownySettings.isTownRespawning() || TownyAPI.getInstance().getTown(player) == null)
             return false;
 

--- a/src/main/java/dev/warriorrr/simplertp/compat/TownyCompat.java
+++ b/src/main/java/dev/warriorrr/simplertp/compat/TownyCompat.java
@@ -9,22 +9,21 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 public class TownyCompat {
-    public boolean isWilderness(Location location) {
-        return TownyAPI.getInstance().isWilderness(location);
+    private static boolean enabled;
+
+    public static void enable() {
+        enabled = true;
+    }
+    public static boolean getEnabled() {
+        return enabled;
     }
 
-    public boolean isWilderness(World world, int x, int z) {
+    public static boolean isWilderness(World world, int x, int z) {
         return TownyAPI.getInstance().isWilderness(WorldCoord.parseWorldCoord(world.getName(), x, z));
     }
 
-    public boolean hasTown(Player player) {
-        Resident resident = TownyAPI.getInstance().getResident(player);
-
-        return resident != null && resident.hasTown();
-    }
-
-    public boolean handlesRespawn(Player player, Location deathLocation) {
-        if (!TownySettings.isTownRespawning() || !hasTown(player))
+    public static boolean handlesRespawn(Player player, Location deathLocation) {
+        if (!TownySettings.isTownRespawning() || TownyAPI.getInstance().getTown(player) == null)
             return false;
 
         if (TownySettings.isTownRespawningInOtherWorlds())

--- a/src/main/java/dev/warriorrr/simplertp/model/Area.java
+++ b/src/main/java/dev/warriorrr/simplertp/model/Area.java
@@ -1,0 +1,7 @@
+package dev.warriorrr.simplertp.model;
+
+public record Area(int minX, int maxX, int minZ, int maxZ) {
+    public int size() {
+        return (maxX - minX) * (maxZ - minZ);
+    }
+}

--- a/src/main/java/dev/warriorrr/simplertp/model/GeneratedLocation.java
+++ b/src/main/java/dev/warriorrr/simplertp/model/GeneratedLocation.java
@@ -1,0 +1,6 @@
+package dev.warriorrr.simplertp.model;
+
+import org.bukkit.Location;
+
+public record GeneratedLocation(Region region, Location location) {
+}

--- a/src/main/java/dev/warriorrr/simplertp/model/Region.java
+++ b/src/main/java/dev/warriorrr/simplertp/model/Region.java
@@ -1,0 +1,45 @@
+package dev.warriorrr.simplertp.model;
+
+import dev.warriorrr.simplertp.collection.WeightedCollection;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class Region {
+    private final String name;
+    private final List<Area> areas;
+    private final WeightedCollection<Area> weightedAreas = new WeightedCollection<>();
+
+    public Region(String name, List<Area> areas) {
+        this.name = name;
+        this.areas = Collections.unmodifiableList(areas);
+
+        for (final Area area : areas) {
+            weightedAreas.add(area.size(), area);
+        }
+    }
+
+    public Area getRandomArea() {
+        return this.weightedAreas.next();
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public List<Area> areas() {
+        return this.areas;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Region region)) return false;
+        return Objects.equals(name, region.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,11 +5,6 @@ random-teleport-on-first-join: true
 
 respawn-nearby-on-death: false
 
-minX: -100
-maxX: 100
-minZ: -100
-maxZ: 100
-
 maxY: 128
 
 blacklisted-biomes:
@@ -32,3 +27,11 @@ blacklisted-biomes:
 
 blacklisted-blocks:
   - leaves
+
+regions:
+  default:
+    areas:
+      - minX: -100
+        maxX: 100
+        minZ: -100
+        maxZ: 100

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -21,8 +21,12 @@ permissions:
     children:
       simplertp.command.rtp.others: true
       simplertp.command.rtp.reload: true
+      simplertp.command.rtp.debug: true
 
   simplertp.command.rtp.others:
     default: op
     children:
       simplertp.command.rtp: true
+
+  simplertp.teleport.nowarmup:
+    default: false


### PR DESCRIPTION
To do:
- Ability to specify continents for regions (to enable /rtp {continent})
- change the chances of a region being selected depending on its size
- cooldown
- improve generateRespawnLocation
right now if the randomly chosen block happens to be "not safe" it returns a random TP location
 could instead loop a few times to check for more available blocks.