### PR TITLE
Updated paper-api to 1.21.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.10-R0.1-SNAPSHOT")
     compileOnly("com.palmergames.bukkit.towny:towny:0.100.0.0")
 }
 

--- a/src/main/java/net/earthmc/simplertp/RTPConfig.java
+++ b/src/main/java/net/earthmc/simplertp/RTPConfig.java
@@ -1,5 +1,6 @@
 package net.earthmc.simplertp;
 
+import io.papermc.paper.registry.RegistryKey;
 import net.earthmc.simplertp.model.Area;
 import net.earthmc.simplertp.model.Region;
 import org.bukkit.Material;
@@ -21,6 +22,8 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
+
+import static io.papermc.paper.registry.RegistryAccess.registryAccess;
 
 public class RTPConfig {
     private final SimpleRTP plugin;
@@ -52,7 +55,7 @@ public class RTPConfig {
                 continue;
             }
 
-            final Biome biome = Registry.BIOME.get(key);
+            final Biome biome = registryAccess().getRegistry((RegistryKey.BIOME)).get(key);
             if (biome != null) {
                 blacklistedBiomes.add(biome);
 


### PR DESCRIPTION
Uses new AsyncPlayerSpawnLocationEvent in order to fix an issue with players being rtp'd every join despite not first-join.

There is probably a better way to do this, but just thought to inform.